### PR TITLE
Fix for the 'mark active actions with asterisk' option initialization

### DIFF
--- a/scripts/token-action-hud.js
+++ b/scripts/token-action-hud.js
@@ -49,7 +49,7 @@ export class TokenActionHud extends Application {
      * @public
      */
     async init () {
-        this.activeCssAsTextSetting = Utils.getSetting('activeCssAsTextSetting')
+        this.activeCssAsTextSetting = Utils.getSetting('activeCssAsText')
         this.allowSetting = Utils.getSetting('allow')
         this.alwaysShowSetting = Utils.getSetting('alwaysShowHud')
         this.clickOpenCategorySetting = Utils.getSetting('clickOpenCategory')


### PR DESCRIPTION
The 'Mark Active Actions with Asterisk' option required unchecking it, saving, rechecking it, and saving every time the browser was refreshed.

It looks like the issue was a mislabeled getSetting string input.

I corrected and successfully tested this fix on a local system.