### PR TITLE
Removed # from selectOptions

### DIFF
--- a/templates/settings.hbs
+++ b/templates/settings.hbs
@@ -8,7 +8,7 @@
 
             {{else if this.isSelect}}
             <select name="{{this.id}}" data-dtype="{{this.type}}">
-                {{#selectOptions choices=this.choices selected=this.value localize=true}}
+                {{selectOptions choices=this.choices selected=this.value localize=true}}
             </select>
 
             {{else if this.isRange}}


### PR DESCRIPTION
The selectOptions helper was preventing use of the layout settings form (maybe others too?) with the error "selectOptions doesn't match if". I believe this leading hash was the culprit.